### PR TITLE
Added missing "}" to skin JSON generation

### DIFF
--- a/photoshop/PhotoshopToSpine.jsx
+++ b/photoshop/PhotoshopToSpine.jsx
@@ -344,7 +344,7 @@ function run () {
 				json += " }" + (++skinLayerIndex < skinLayersCount ? ",\n" : "\n");
 			}
 
-			json += "\t\t\}" + (++skinIndex <= skinsCount ? ",\n" : "\n");
+			json += "\t\t\}," + (++skinIndex <= skinsCount ? ",\n" : "\n");
 		}
 
 		json += "\t}" + (++skinIndex <= skinsCount ? ",\n" : "\n");


### PR DESCRIPTION
The missing } at the end of each skin assignment block led to malformed JSON and as such errors on importing into Spine