### PR TITLE
Make InkscapeToSpine compatible with version > 1.x

### DIFF
--- a/inkscape/InkscapeToSpine.py
+++ b/inkscape/InkscapeToSpine.py
@@ -121,7 +121,7 @@ class SpineExporter(inkex.Effect):
 		p = run_inkscape(["--shell"])
 		stdin = []
 		for k in ("x", "y", "width", "height"):
-			stdin.append("--file=%r --query-id=%s --query-%s " % (self.svg_file, id, k)) # line 124
+			stdin.append("--file=%r --query-id=%s --query-%s " % (self.options.input_file, id, k)) # line 124
 		stdin.append("")  # For the last command
 		stdout, stderr = p.communicate("\n".join(stdin))
 		# Remove the "Inkscape interactive shell mode" noise
@@ -258,7 +258,7 @@ class SpineExporter(inkex.Effect):
 				"--export-id-only",
 				"--export-id", id,
 				"--export-dpi", str(self.options.dpi),
-				"--file", self.args[-1],
+				"--file", self.options.input_file,
 			)
 
 			process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -283,4 +283,4 @@ class SpineExporter(inkex.Effect):
 
 inkex.localization.localize()
 effect = SpineExporter()
-effect.affect()
+effect.run()

--- a/inkscape/InkscapeToSpine.py
+++ b/inkscape/InkscapeToSpine.py
@@ -281,6 +281,6 @@ class SpineExporter(inkex.Effect):
 				json.dump(spine_struct, f, **args)
 
 
-inkex.localize()
+inkex.localization.localize()
 effect = SpineExporter()
 effect.affect()

--- a/inkscape/InkscapeToSpine.py
+++ b/inkscape/InkscapeToSpine.py
@@ -38,44 +38,44 @@ def parse_css_style(style):
 class SpineExporter(inkex.Effect):
 	def __init__(self):
 		inkex.Effect.__init__(self)
-		self.OptionParser.add_option(
+		self.arg_parser.add_argument(
 			"--outdir",
 			action="store",
-			type="string",
+			type=str,
 			dest="outdir",
 			default="~",
 			help="Path to the export directory"
 		)
-		self.OptionParser.add_option(
+		self.arg_parser.add_argument(
 			"--dpi",
 			action="store",
-			type="float",
+			type=float,
 			dest="dpi",
 			default=90.0,
 			help="Resolution to export at"
 		)
-		self.OptionParser.add_option(
+		self.arg_parser.add_argument(
 			"--json",
-			type="inkbool",
+			type=inkex.Boolean,
 			dest="json",
 			help="Create a Spine JSON file",
 		)
-		self.OptionParser.add_option(
+		self.arg_parser.add_argument(
 			"--ignore-hidden",
-			type="inkbool",
+			type=inkex.Boolean,
 			dest="ignore_hidden",
 			help="Ignore hidden layers",
 		)
-		self.OptionParser.add_option(
+		self.arg_parser.add_argument(
 			"--pretty-print",
-			type="inkbool",
+			type=inkex.Boolean,
 			dest="pretty",
 			help="Pretty-print the JSON file",
 		)
-		self.OptionParser.add_option(
+		self.arg_parser.add_argument(
 			"--merge",
 			action="store",
-			type="string",
+			type=str,
 			dest="merge",
 			default="",
 			help="Spine JSON file to merge with"

--- a/inkscape/InkscapeToSpine.py
+++ b/inkscape/InkscapeToSpine.py
@@ -86,15 +86,15 @@ class SpineExporter(inkex.Effect):
 		self.bone_coords = {}
 
 	@property
-	def svg(self):
+	def root(self):
 		return self.document.getroot()
 
 	@property
 	def friendly_name(self):
-		docname = self.svg.xpath("//@sodipodi:docname", namespaces=inkex.NSS)
+		docname = self.root.xpath("//@sodipodi:docname", namespaces=inkex.NSS)
 		if docname:
 			return docname[0].replace(".svg", "")
-		return self.svg.attrib["id"]
+		return self.root.attrib["id"]
 
 	@property
 	def layers(self):
@@ -110,11 +110,11 @@ class SpineExporter(inkex.Effect):
 				ret.append(e)
 			return ret
 
-		return get_layers(self.svg)
+		return get_layers(self.root)
 
 	@property
 	def drawing_size(self):
-		x, y, width, height = self.get_bounding_box(self.svg.attrib["id"])
+		x, y, width, height = self.get_bounding_box(self.root.attrib["id"])
 		return width, height
 
 	def get_bounding_box(self, id):

--- a/inkscape/InkscapeToSpine.py
+++ b/inkscape/InkscapeToSpine.py
@@ -257,16 +257,15 @@ class SpineExporter(inkex.Effect):
 
 			command = (
 				"inkscape",
-				"--export-png", outfile,
+				self.options.input_file,
+				"--export-filename", outfile,
 				"--export-id-only",
 				"--export-id", id,
 				"--export-dpi", str(self.options.dpi),
-				"--file", self.options.input_file,
 			)
 
-			process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-			process.wait()
-
+			with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as process:
+				process.wait()
 			bbox = self.get_bounding_box(id)
 			self.merge_spine_skin(spine_struct, label, bbox)
 			# Slot merge must come after the skin merge because we need the

--- a/inkscape/PathsToSpine.py
+++ b/inkscape/PathsToSpine.py
@@ -49,8 +49,8 @@ class path2spine(inkex.Effect):
 		self.own_slot = self.options.own_slot
 		self.selected_only = self.options.selected_only
 		self.corner_type = self.options.corner_type
-		self.hw = self.unittouu(self.getDocumentWidth()) / 2
-		self.hh = self.unittouu(self.getDocumentHeight()) / 2
+		self.hw = self.svg.unittouu(self.svg.width) / 2
+		self.hh = self.svg.unittouu(self.svg.height) / 2
 
 		if not self.own_slot:
 			data["slots"].append({"name": "paths", "bone": "root"})
@@ -296,7 +296,7 @@ class path2spine(inkex.Effect):
 
 	def _main_function(self):
 		if self.selected_only:
-			for id, node in self.selected.iteritems():
+			for id, node in self.svg.selected.iteritems():
 				self.traverse(node, [], [])
 		else:
 			for node in self.document.getroot().iterchildren():
@@ -305,4 +305,4 @@ class path2spine(inkex.Effect):
 		self.save(self.filename)
 
 e = path2spine()
-e.affect()
+e.run()

--- a/inkscape/PathsToSpine.py
+++ b/inkscape/PathsToSpine.py
@@ -27,7 +27,6 @@ THE SOFTWARE.
 '''
 
 import os, inkex, simplestyle, simpletransform, simplepath, cubicsuperpath, json
-from string import rstrip
 from math import sqrt
 
 data = {
@@ -247,7 +246,7 @@ class path2spine(inkex.Effect):
 		subpaths = path.split('M')
 
 		for i in range(1, len(subpaths)):
-			subpaths[i] = 'M ' + rstrip(subpaths[i])
+			subpaths[i] = 'M ' + str.rstrip(subpaths[i])
 			closed = subpaths[i][-1] in ['Z', 'z']
 
 			csp = cubicsuperpath.parsePath(subpaths[i])

--- a/inkscape/PathsToSpine.py
+++ b/inkscape/PathsToSpine.py
@@ -39,10 +39,10 @@ data = {
 class path2spine(inkex.Effect):
 	def __init__(self):
 		inkex.Effect.__init__(self)
-		self.OptionParser.add_option("-f", "--filename", action = "store", type = "string", dest = "filename", default = "~/paths.json", help = "File to export")
-		self.OptionParser.add_option("-o", "--own_slot", action = "store", type = "inkbool", dest = "own_slot", default = True, help = "Export each path in its own slot")
-		self.OptionParser.add_option("-s", "--selected_only", action = "store", type = "inkbool", dest = "selected_only", default = True, help = "Export only selected paths")
-		self.OptionParser.add_option("-c", "--corner_type", action = "store", type = "string", dest = "corner_type", default = "curve", help = "Corner type for open paths")
+		self.arg_parser.add_argument("-f", "--filename", action = "store", type = str, dest = "filename", default = "~/paths.json", help = "File to export")
+		self.arg_parser.add_argument("-o", "--own_slot", action = "store", type = inkex.Boolean, dest = "own_slot", default = True, help = "Export each path in its own slot")
+		self.arg_parser.add_argument("-s", "--selected_only", action = "store", type = inkex.Boolean, dest = "selected_only", default = True, help = "Export only selected paths")
+		self.arg_parser.add_argument("-c", "--corner_type", action = "store", type = str, dest = "corner_type", default = "curve", help = "Corner type for open paths")
 
 	def effect(self):
 		self.filename = self.options.filename

--- a/inkscape/PathsToSpine.py
+++ b/inkscape/PathsToSpine.py
@@ -296,7 +296,7 @@ class path2spine(inkex.Effect):
 
 	def _main_function(self):
 		if self.selected_only:
-			for id, node in self.svg.selected.iteritems():
+			for id, node in self.svg.selection.items():
 				self.traverse(node, [], [])
 		else:
 			for node in self.document.getroot().iterchildren():


### PR DESCRIPTION
I tried to patch things up and make them work with Inkscape version 1.x. The export from Inkscape to Spine should now be working with Inkscape version > 1.x. However I still have problems with PathsToSpine.py. All deprecation warnings should be fixed but the comparison in is_line still fails and I do not know why. I however thought I still should submit my current state of work. Perhaps it would be better to just approve the fixes in InkscapeToSpine and leave out the other file. If you have any further questions please do not hesitate to contact me :). 